### PR TITLE
Fix repetition of tree_method hyper-parameter in xgboost_hist

### DIFF
--- a/docs/Experiments.rst
+++ b/docs/Experiments.rst
@@ -73,7 +73,6 @@ We set up total 3 settings for experiments. The parameters of these settings are
        eta = 0.1
        num_round = 500
        nthread = 16
-       tree_method = approx
        min_child_weight = 100
        tree_method = hist
        grow_policy = lossguide

--- a/docs/Parallel-Learning-Guide.rst
+++ b/docs/Parallel-Learning-Guide.rst
@@ -138,7 +138,7 @@ Example
 
 .. _The following example: https://github.com/Azure/mmlspark/blob/master/notebooks/samples/LightGBM%20-%20Quantile%20Regression%20for%20Drug%20Discovery.ipynb
 
-.. _Kubeflow Fairing: https://www.kubeflow.org/docs/fairing/fairing-overview
+.. _Kubeflow Fairing: https://www.kubeflow.org/docs/components/fairing/fairing-overview
 
 .. _These examples: https://github.com/kubeflow/fairing/tree/master/examples/lightgbm
 

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -5,9 +5,9 @@
  * \note
  * To avoid type conversion on large data, the most of our exposed interface supports both float32 and float64,
  * except the following:
- *   1. gradient and Hessian;
- *   2. current score for training and validation data.
- *   .
+ * 1. gradient and Hessian;
+ * 2. current score for training and validation data.
+ * .
  * The reason is that they are called frequently, and the type conversion on them may be time-cost.
  */
 #ifndef LIGHTGBM_C_API_H_


### PR DESCRIPTION
Fixes #3290, by removing the duplicated `tree_method = approx` from hyper-parameter setting of `xgboost_hist`. 